### PR TITLE
[FEATURE] Ad disclosure content type CLCAD-3

### DIFF
--- a/backend/src/api/ad-disclosure/content-types/ad-disclosure/schema.json
+++ b/backend/src/api/ad-disclosure/content-types/ad-disclosure/schema.json
@@ -1,0 +1,78 @@
+{
+  "kind": "collectionType",
+  "collectionName": "ad_disclosures",
+  "info": {
+    "singularName": "ad-disclosure",
+    "pluralName": "ad-disclosures",
+    "displayName": "Ad Disclosure",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "adFormat": {
+      "type": "enumeration",
+      "enum": [
+        "Digital",
+        "Print",
+        "Direct Mail",
+        "Tv",
+        "Radio"
+      ],
+      "required": true
+    },
+    "adSpend": {
+      "type": "decimal",
+      "required": true
+    },
+    "targetAudience": {
+      "type": "text"
+    },
+    "viewCount": {
+      "type": "integer"
+    },
+    "clickCount": {
+      "type": "integer"
+    },
+    "authorizedAdSpend": {
+      "type": "decimal"
+    },
+    "externalLink": {
+      "type": "string",
+      "regex": "^(http(s):\\/\\/.)[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)$"
+    },
+    "startDate": {
+      "type": "date",
+      "required": true
+    },
+    "endDate": {
+      "type": "date",
+      "required": true
+    },
+    "adTextContent": {
+      "type": "text"
+    },
+    "adElection": {
+      "type": "enumeration",
+      "enum": [
+        "Election 1",
+        "Election 2",
+        "Election 3"
+      ],
+      "required": true
+    },
+    "adMedia": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": true,
+      "required": true
+    }
+  }
+}

--- a/backend/src/api/ad-disclosure/content-types/ad-disclosure/schema.json
+++ b/backend/src/api/ad-disclosure/content-types/ad-disclosure/schema.json
@@ -64,14 +64,20 @@
       "required": true
     },
     "adMedia": {
+      "type": "media",
+      "multiple": true,
+      "required": true,
       "allowedTypes": [
         "images",
         "files",
         "videos",
         "audios"
-      ],
-      "type": "media",
-      "multiple": true,
+      ]
+    },
+    "candidatesMeasuresAndPoliticalParties": {
+      "type": "component",
+      "repeatable": true,
+      "component": "ad-disclosure.candidates-measures-and-or-political-parties",
       "required": true
     }
   }

--- a/backend/src/api/ad-disclosure/controllers/ad-disclosure.ts
+++ b/backend/src/api/ad-disclosure/controllers/ad-disclosure.ts
@@ -1,0 +1,7 @@
+/**
+ * ad-disclosure controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::ad-disclosure.ad-disclosure');

--- a/backend/src/api/ad-disclosure/routes/ad-disclosure.ts
+++ b/backend/src/api/ad-disclosure/routes/ad-disclosure.ts
@@ -1,0 +1,7 @@
+/**
+ * ad-disclosure router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::ad-disclosure.ad-disclosure');

--- a/backend/src/api/ad-disclosure/services/ad-disclosure.ts
+++ b/backend/src/api/ad-disclosure/services/ad-disclosure.ts
@@ -1,0 +1,7 @@
+/**
+ * ad-disclosure service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::ad-disclosure.ad-disclosure');

--- a/backend/src/components/ad-disclosure/candidates-measures-and-or-political-parties.json
+++ b/backend/src/components/ad-disclosure/candidates-measures-and-or-political-parties.json
@@ -1,0 +1,24 @@
+{
+  "collectionName": "components_ad_disclosure_candidates_measures_and_or_political_parties",
+  "info": {
+    "displayName": "Candidate, Measure, and/or Political Party",
+    "icon": "bulletList",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "name": {
+      "type": "string",
+      "required": true
+    },
+    "stance": {
+      "type": "enumeration",
+      "enum": [
+        "Supports",
+        "Opposes",
+        "Neither"
+      ],
+      "required": true
+    }
+  }
+}


### PR DESCRIPTION
# Overview

This pull request creates the `adDisclosure` content type with all optional and required fields. The following fields are added to the content type:

* ad format
* ad spend
* target audience
* view count
* click count
* authorized ad spend
* external link
* start date
* end date
* text content
* election
* media
* candidates, measures and/or political parties

The election select field, for the POC, will just be a hard-coded list. Eventually, this would be a custom field that would get available elections from an external system. We should, however, probably add some better hard-coded values here of what a filer may actually see.

The view configuration in Strapi gets saved to the database instead of being configured in code. Therefore, we'll want to update this view to give it a better layout and include placholder and helper text for fields. I am researching a good way for us to move the DBs around, but for now I think it's fine to just update the production instance of Strapi once the PR is merged.

## TODO

- [ ] Configure view in production instance after merge to provide better layout of fields and provide helper/placeholder text
- [ ] Update user roles so that Admin, Super Admin, and Filers can CRUD ad disclosures

## Screenshot
![Content Manager 2023-08-31 11-42-46](https://github.com/maplight/clc-ad-transparency/assets/38389357/730e1708-9cfb-4ab7-a85a-6766df6c6964)

## Tasks
[CLCAD-3](https://maplight.atlassian.net/browse/CLCAD-3)
[CLCAD-9](https://maplight.atlassian.net/browse/CLCAD-9)
[CLCAD-10](https://maplight.atlassian.net/browse/CLCAD-10)
[CLCAD-11](https://maplight.atlassian.net/browse/CLCAD-11)
[CLCAD-12](https://maplight.atlassian.net/browse/CLCAD-12)
[CLCAD-13](https://maplight.atlassian.net/browse/CLCAD-13)
[CLCAD-15](https://maplight.atlassian.net/browse/CLCAD-15)
[CLCAD-23](https://maplight.atlassian.net/browse/CLCAD-23)
[CLCAD-25](https://maplight.atlassian.net/browse/CLCAD-25)
[CLCAD-26](https://maplight.atlassian.net/browse/CLCAD-26)
[CLCAD-27](https://maplight.atlassian.net/browse/CLCAD-27)
[CLCAD-28](https://maplight.atlassian.net/browse/CLCAD-28)
[CLCAD-29](https://maplight.atlassian.net/browse/CLCAD-29)

[CLCAD-3]: https://maplight.atlassian.net/browse/CLCAD-3?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ