### PR TITLE
[Task] hiding settings from non-super-admins CLCAD-56

### DIFF
--- a/backend/patches/@strapi+admin+4.12.7.patch
+++ b/backend/patches/@strapi+admin+4.12.7.patch
@@ -30,3 +30,21 @@ index 9e6f8a7..befec42 100644
        ].map((section) => ({
          ...section,
          links: section.links
+diff --git a/node_modules/@strapi/admin/admin/src/hooks/useMenu/utils/getGeneralLinks.js b/node_modules/@strapi/admin/admin/src/hooks/useMenu/utils/getGeneralLinks.js
+index fac6937..1fe141f 100644
+--- a/node_modules/@strapi/admin/admin/src/hooks/useMenu/utils/getGeneralLinks.js
++++ b/node_modules/@strapi/admin/admin/src/hooks/useMenu/utils/getGeneralLinks.js
+@@ -2,7 +2,13 @@ import cloneDeep from 'lodash/cloneDeep';
+
+ import checkPermissions from './checkPermissions';
+
++//only super admins should have this setting
++const UPDATE_PROJECT_SETTINGS = 'admin::project-settings.update';
++
+ const getGeneralLinks = async (userPermissions, generalSectionRawLinks, shouldUpdateStrapi) => {
++  if (!userPermissions.some((permission) => permission.action ===UPDATE_PROJECT_SETTINGS)){
++    return [];
++  }
+   const generalSectionPermissionsPromises = checkPermissions(
+     userPermissions,
+     generalSectionRawLinks

--- a/backend/patches/@strapi+admin+4.12.7.patch
+++ b/backend/patches/@strapi+admin+4.12.7.patch
@@ -10,3 +10,23 @@ index c259beb..cb4ab10 100644
          workplace={formatMessage({
            id: 'app.components.LeftMenu.navbrand.workplace',
            defaultMessage: 'Workplace',
+diff --git a/node_modules/@strapi/admin/admin/src/content-manager/pages/App/LeftMenu/index.js b/node_modules/@strapi/admin/admin/src/content-manager/pages/App/LeftMenu/index.js
+index 9e6f8a7..befec42 100644
+--- a/node_modules/@strapi/admin/admin/src/content-manager/pages/App/LeftMenu/index.js
++++ b/node_modules/@strapi/admin/admin/src/content-manager/pages/App/LeftMenu/index.js
+@@ -50,15 +50,6 @@ const LeftMenu = () => {
+           searchable: true,
+           links: collectionTypeLinks,
+         },
+-        {
+-          id: 'singleTypes',
+-          title: {
+-            id: getTrad('components.LeftMenu.single-types'),
+-            defaultMessage: 'Single Types',
+-          },
+-          searchable: true,
+-          links: singleTypeLinks,
+-        },
+       ].map((section) => ({
+         ...section,
+         links: section.links


### PR DESCRIPTION
I'm not a fan of this implementation, but I've patched the global links so that if a user doesn't have the permission admin::project-settings.update (they aren't a super admin) they will not see the settings link.

![image](https://github.com/maplight/clc-ad-transparency/assets/1364700/1191f3f4-b9b7-4c64-a012-8d1c58d2c8e2)
