### PR TITLE
[BUG] Patching a few more redirects to the welcome page CLCAD-59

### DIFF
--- a/backend/patches/@strapi+admin+4.12.7.patch
+++ b/backend/patches/@strapi+admin+4.12.7.patch
@@ -1,7 +1,16 @@
 diff --git a/node_modules/@strapi/admin/admin/src/components/LeftMenu/index.js b/node_modules/@strapi/admin/admin/src/components/LeftMenu/index.js
-index c259beb..cb4ab10 100644
+index c259beb..6fd4f9d 100644
 --- a/node_modules/@strapi/admin/admin/src/components/LeftMenu/index.js
 +++ b/node_modules/@strapi/admin/admin/src/components/LeftMenu/index.js
+@@ -80,7 +80,7 @@ const LeftMenu = ({ generalSectionLinks, pluginsSectionLinks }) => {
+     await post('/admin/logout');
+     auth.clearAppStorage();
+     handleToggleUserLinks();
+-    history.push('/auth/login');
++    history.push('/content-manager');
+   };
+
+   const handleBlur = (e) => {
 @@ -105,6 +105,7 @@ const LeftMenu = ({ generalSectionLinks, pluginsSectionLinks }) => {
      <MainNav condensed={condensed}>
        <NavBrand
@@ -30,3 +39,39 @@ index 9e6f8a7..befec42 100644
        ].map((section) => ({
          ...section,
          links: section.links
+diff --git a/node_modules/@strapi/admin/admin/src/pages/AuthPage/index.js b/node_modules/@strapi/admin/admin/src/pages/AuthPage/index.js
+index 0f3c656..f7d1358 100644
+--- a/node_modules/@strapi/admin/admin/src/pages/AuthPage/index.js
++++ b/node_modules/@strapi/admin/admin/src/pages/AuthPage/index.js
+@@ -228,7 +228,7 @@ const AuthPage = ({ hasAdmin, setHasAdmin }) => {
+       auth.setUserInfo(user, false);
+
+       // Redirect to the homePage
+-      push('/');
++      push('/content-manager');
+     } catch (err) {
+       if (err.response) {
+         const errorMessage = get(err, ['response', 'data', 'message'], 'Something went wrong');
+@@ -249,11 +249,11 @@ const AuthPage = ({ hasAdmin, setHasAdmin }) => {
+   const redirectToPreviousLocation = () => {
+     if (authType === 'login') {
+       const redirectTo = query.get('redirectTo');
+-      const redirectUrl = redirectTo ? decodeURIComponent(redirectTo) : '/';
++      const redirectUrl = redirectTo ? decodeURIComponent(redirectTo) : '/content-manager';
+
+       push(redirectUrl);
+     } else {
+-      push('/');
++      push('/content-manager');
+     }
+   };
+
+@@ -262,7 +262,7 @@ const AuthPage = ({ hasAdmin, setHasAdmin }) => {
+   // there is already an admin user oo
+   // the user is already logged in
+   if (!forms[authType] || (hasAdmin && authType === 'register-admin') || auth.getToken()) {
+-    return <Redirect to="/" />;
++    return <Redirect to="/content-manager" />;
+   }
+
+   // Redirect the user to the register-admin if it is the first user


### PR DESCRIPTION
Users were able to access the welcome page after logging out or when trying to access /admin/auth/** paths directly.  This pr should send them to the content manager instead.