### PR TITLE
[BUGFIX] Server error when indexing to Algolia CLCAD-40

### DIFF
--- a/backend/src/plugins/ad-disclosure-report/admin/src/components/AdDisclosureTable/index.tsx
+++ b/backend/src/plugins/ad-disclosure-report/admin/src/components/AdDisclosureTable/index.tsx
@@ -16,22 +16,15 @@ import {
 } from '@strapi/helper-plugin';
 import useAdDisclosureReportData from '../../hooks/use-ad-disclosure-report-data';
 import useIsAdmin from '../../hooks/use-is-admin';
+import type { ApiAdDisclosureAdDisclosure } from '../../../../../../../types/generated/contentTypes';
 
-// TODO: We can probably infer this type from the schema
-type AdDisclosure = {
-  attributes: {
-    adFormat: string;
-    adSpend: string;
-    targetAudience: string;
-  }
+type AdDisclosure = ApiAdDisclosureAdDisclosure & {
   id: number;
 }
 
 const AdDisclosureTable = ({ attribute,  name, onChange, value }): ReactElement => {
   const { fetchAdDisclosures, fetchFilingPeriod } = useAdDisclosureReportData();
   const isAdmin = useIsAdmin();
-
-  console.log(isAdmin)
 
   const {
     modifiedData:  {

--- a/backend/src/plugins/ad-disclosure-report/admin/src/hooks/use-ad-disclosure-report-data.ts
+++ b/backend/src/plugins/ad-disclosure-report/admin/src/hooks/use-ad-disclosure-report-data.ts
@@ -10,10 +10,12 @@ const useAdDisclosureReportData = () => {
     try {
       const userInfo = auth.get('userInfo')
 
+      const hasUserInfo = userInfo && typeof userInfo !== 'string';
+
       const filters = [
         `[endDate][$gte]=${filingPeriodStartDate}`,
         `[endDate][$lte]=${filingPeriodEndDate}`,
-        `[createdBy][id][$eq]=${userInfo.id}`,
+         hasUserInfo ? `[createdBy][id][$eq]=${userInfo.id}` : '',
       ];
 
       const url = `/api/ad-disclosures?${filters.map((filter, index) => `filters[$and][${index}]${filter}&`).join('')}&populate=*`;

--- a/backend/src/plugins/ad-disclosure-report/admin/src/hooks/use-is-admin.ts
+++ b/backend/src/plugins/ad-disclosure-report/admin/src/hooks/use-is-admin.ts
@@ -6,9 +6,9 @@ const CREATE_USER_PERMISSION = 'admin::users.create'
 const useIsAdmin = (): boolean => {
   const { allPermissions } = useRBACProvider();
 
-  return allPermissions.some(
+  return allPermissions?.some(
     (permission) => permission.action === CREATE_USER_PERMISSION
-  );
+  ) || false;
 }
 
 export default useIsAdmin;

--- a/backend/src/plugins/ad-disclosure-report/admin/src/index.tsx
+++ b/backend/src/plugins/ad-disclosure-report/admin/src/index.tsx
@@ -8,7 +8,7 @@ export default {
     app.customFields.register({
       name: 'ad-disclosure-table',
       pluginId: 'ad-disclosure-report',
-      type: 'json',
+      type: 'string',
       icon: AdDisclosureTableIcon,
       intlLabel: {
         id: getTrad('ad-disclosure-table.label'),

--- a/backend/src/plugins/ad-disclosure-report/server/register.ts
+++ b/backend/src/plugins/ad-disclosure-report/server/register.ts
@@ -4,7 +4,7 @@ export default ({ strapi }: { strapi: Strapi }) => {
   strapi.customFields.register({
     name: "ad-disclosure-table",
     plugin: "ad-disclosure-report",
-    type: "json",
+    type: "string",
     inputSize: {
       default: 4,
       isResizable: true,

--- a/backend/types/generated/components.d.ts
+++ b/backend/types/generated/components.d.ts
@@ -1,0 +1,56 @@
+import type { Schema, Attribute } from '@strapi/strapi';
+
+export interface AdDisclosureCandidate extends Schema.Component {
+  collectionName: 'components_ad_disclosure_candidates';
+  info: {
+    displayName: 'Candidate';
+    icon: 'user';
+  };
+  attributes: {
+    name: Attribute.Enumeration<['Candidate 1', 'Candidate 2', 'Candidate 3']> &
+      Attribute.Required;
+    stance: Attribute.Enumeration<['Supports', 'Opposes', 'Neither']> &
+      Attribute.Required;
+  };
+}
+
+export interface AdDisclosureMeasure extends Schema.Component {
+  collectionName: 'components_ad_disclosure_measures';
+  info: {
+    displayName: 'Measure';
+    icon: 'file';
+    description: '';
+  };
+  attributes: {
+    name: Attribute.Enumeration<
+      ['Measure 1', 'Measure 2', 'Measure 3', 'Measure 4', 'Measure 5']
+    > &
+      Attribute.Required;
+    stance: Attribute.Enumeration<['Supports', 'Opposes', 'Neither']> &
+      Attribute.Required;
+  };
+}
+
+export interface AdDisclosurePoliticalParty extends Schema.Component {
+  collectionName: 'components_ad_disclosure_political_parties';
+  info: {
+    displayName: 'Political Party';
+    icon: 'bulletList';
+  };
+  attributes: {
+    name: Attribute.Enumeration<['Party 1', 'Party 2', 'Party 3', 'Party 4']> &
+      Attribute.Required;
+    stance: Attribute.Enumeration<['Supports', 'Opposes', 'Neither']> &
+      Attribute.Required;
+  };
+}
+
+declare module '@strapi/types' {
+  export module Shared {
+    export interface Components {
+      'ad-disclosure.candidate': AdDisclosureCandidate;
+      'ad-disclosure.measure': AdDisclosureMeasure;
+      'ad-disclosure.political-party': AdDisclosurePoliticalParty;
+    }
+  }
+}

--- a/backend/types/generated/contentTypes.d.ts
+++ b/backend/types/generated/contentTypes.d.ts
@@ -1,0 +1,669 @@
+import type { Schema, Attribute } from '@strapi/strapi';
+
+export interface AdminPermission extends Schema.CollectionType {
+  collectionName: 'admin_permissions';
+  info: {
+    name: 'Permission';
+    description: '';
+    singularName: 'permission';
+    pluralName: 'permissions';
+    displayName: 'Permission';
+  };
+  pluginOptions: {
+    'content-manager': {
+      visible: false;
+    };
+    'content-type-builder': {
+      visible: false;
+    };
+  };
+  attributes: {
+    action: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    actionParameters: Attribute.JSON & Attribute.DefaultTo<{}>;
+    subject: Attribute.String &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    properties: Attribute.JSON & Attribute.DefaultTo<{}>;
+    conditions: Attribute.JSON & Attribute.DefaultTo<[]>;
+    role: Attribute.Relation<'admin::permission', 'manyToOne', 'admin::role'>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'admin::permission',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'admin::permission',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface AdminUser extends Schema.CollectionType {
+  collectionName: 'admin_users';
+  info: {
+    name: 'User';
+    description: '';
+    singularName: 'user';
+    pluralName: 'users';
+    displayName: 'User';
+  };
+  pluginOptions: {
+    'content-manager': {
+      visible: false;
+    };
+    'content-type-builder': {
+      visible: false;
+    };
+  };
+  attributes: {
+    firstname: Attribute.String &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    lastname: Attribute.String &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    username: Attribute.String;
+    email: Attribute.Email &
+      Attribute.Required &
+      Attribute.Private &
+      Attribute.Unique &
+      Attribute.SetMinMaxLength<{
+        minLength: 6;
+      }>;
+    password: Attribute.Password &
+      Attribute.Private &
+      Attribute.SetMinMaxLength<{
+        minLength: 6;
+      }>;
+    resetPasswordToken: Attribute.String & Attribute.Private;
+    registrationToken: Attribute.String & Attribute.Private;
+    isActive: Attribute.Boolean &
+      Attribute.Private &
+      Attribute.DefaultTo<false>;
+    roles: Attribute.Relation<'admin::user', 'manyToMany', 'admin::role'> &
+      Attribute.Private;
+    blocked: Attribute.Boolean & Attribute.Private & Attribute.DefaultTo<false>;
+    preferedLanguage: Attribute.String;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'admin::user', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<'admin::user', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+  };
+}
+
+export interface AdminRole extends Schema.CollectionType {
+  collectionName: 'admin_roles';
+  info: {
+    name: 'Role';
+    description: '';
+    singularName: 'role';
+    pluralName: 'roles';
+    displayName: 'Role';
+  };
+  pluginOptions: {
+    'content-manager': {
+      visible: false;
+    };
+    'content-type-builder': {
+      visible: false;
+    };
+  };
+  attributes: {
+    name: Attribute.String &
+      Attribute.Required &
+      Attribute.Unique &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    code: Attribute.String &
+      Attribute.Required &
+      Attribute.Unique &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    description: Attribute.String;
+    users: Attribute.Relation<'admin::role', 'manyToMany', 'admin::user'>;
+    permissions: Attribute.Relation<
+      'admin::role',
+      'oneToMany',
+      'admin::permission'
+    >;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'admin::role', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<'admin::role', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+  };
+}
+
+export interface AdminApiToken extends Schema.CollectionType {
+  collectionName: 'strapi_api_tokens';
+  info: {
+    name: 'Api Token';
+    singularName: 'api-token';
+    pluralName: 'api-tokens';
+    displayName: 'Api Token';
+    description: '';
+  };
+  pluginOptions: {
+    'content-manager': {
+      visible: false;
+    };
+    'content-type-builder': {
+      visible: false;
+    };
+  };
+  attributes: {
+    name: Attribute.String &
+      Attribute.Required &
+      Attribute.Unique &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    description: Attribute.String &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }> &
+      Attribute.DefaultTo<''>;
+    type: Attribute.Enumeration<['read-only', 'full-access', 'custom']> &
+      Attribute.Required &
+      Attribute.DefaultTo<'read-only'>;
+    accessKey: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    lastUsedAt: Attribute.DateTime;
+    permissions: Attribute.Relation<
+      'admin::api-token',
+      'oneToMany',
+      'admin::api-token-permission'
+    >;
+    expiresAt: Attribute.DateTime;
+    lifespan: Attribute.BigInteger;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'admin::api-token',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'admin::api-token',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface AdminApiTokenPermission extends Schema.CollectionType {
+  collectionName: 'strapi_api_token_permissions';
+  info: {
+    name: 'API Token Permission';
+    description: '';
+    singularName: 'api-token-permission';
+    pluralName: 'api-token-permissions';
+    displayName: 'API Token Permission';
+  };
+  pluginOptions: {
+    'content-manager': {
+      visible: false;
+    };
+    'content-type-builder': {
+      visible: false;
+    };
+  };
+  attributes: {
+    action: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    token: Attribute.Relation<
+      'admin::api-token-permission',
+      'manyToOne',
+      'admin::api-token'
+    >;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'admin::api-token-permission',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'admin::api-token-permission',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface AdminTransferToken extends Schema.CollectionType {
+  collectionName: 'strapi_transfer_tokens';
+  info: {
+    name: 'Transfer Token';
+    singularName: 'transfer-token';
+    pluralName: 'transfer-tokens';
+    displayName: 'Transfer Token';
+    description: '';
+  };
+  pluginOptions: {
+    'content-manager': {
+      visible: false;
+    };
+    'content-type-builder': {
+      visible: false;
+    };
+  };
+  attributes: {
+    name: Attribute.String &
+      Attribute.Required &
+      Attribute.Unique &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    description: Attribute.String &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }> &
+      Attribute.DefaultTo<''>;
+    accessKey: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    lastUsedAt: Attribute.DateTime;
+    permissions: Attribute.Relation<
+      'admin::transfer-token',
+      'oneToMany',
+      'admin::transfer-token-permission'
+    >;
+    expiresAt: Attribute.DateTime;
+    lifespan: Attribute.BigInteger;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'admin::transfer-token',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'admin::transfer-token',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface AdminTransferTokenPermission extends Schema.CollectionType {
+  collectionName: 'strapi_transfer_token_permissions';
+  info: {
+    name: 'Transfer Token Permission';
+    description: '';
+    singularName: 'transfer-token-permission';
+    pluralName: 'transfer-token-permissions';
+    displayName: 'Transfer Token Permission';
+  };
+  pluginOptions: {
+    'content-manager': {
+      visible: false;
+    };
+    'content-type-builder': {
+      visible: false;
+    };
+  };
+  attributes: {
+    action: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    token: Attribute.Relation<
+      'admin::transfer-token-permission',
+      'manyToOne',
+      'admin::transfer-token'
+    >;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'admin::transfer-token-permission',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'admin::transfer-token-permission',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface PluginUploadFile extends Schema.CollectionType {
+  collectionName: 'files';
+  info: {
+    singularName: 'file';
+    pluralName: 'files';
+    displayName: 'File';
+    description: '';
+  };
+  pluginOptions: {
+    'content-manager': {
+      visible: false;
+    };
+    'content-type-builder': {
+      visible: false;
+    };
+  };
+  attributes: {
+    name: Attribute.String & Attribute.Required;
+    alternativeText: Attribute.String;
+    caption: Attribute.String;
+    width: Attribute.Integer;
+    height: Attribute.Integer;
+    formats: Attribute.JSON;
+    hash: Attribute.String & Attribute.Required;
+    ext: Attribute.String;
+    mime: Attribute.String & Attribute.Required;
+    size: Attribute.Decimal & Attribute.Required;
+    url: Attribute.String & Attribute.Required;
+    previewUrl: Attribute.String;
+    provider: Attribute.String & Attribute.Required;
+    provider_metadata: Attribute.JSON;
+    related: Attribute.Relation<'plugin::upload.file', 'morphToMany'>;
+    folder: Attribute.Relation<
+      'plugin::upload.file',
+      'manyToOne',
+      'plugin::upload.folder'
+    > &
+      Attribute.Private;
+    folderPath: Attribute.String &
+      Attribute.Required &
+      Attribute.Private &
+      Attribute.SetMinMax<{
+        min: 1;
+      }>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'plugin::upload.file',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'plugin::upload.file',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface PluginUploadFolder extends Schema.CollectionType {
+  collectionName: 'upload_folders';
+  info: {
+    singularName: 'folder';
+    pluralName: 'folders';
+    displayName: 'Folder';
+  };
+  pluginOptions: {
+    'content-manager': {
+      visible: false;
+    };
+    'content-type-builder': {
+      visible: false;
+    };
+  };
+  attributes: {
+    name: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMax<{
+        min: 1;
+      }>;
+    pathId: Attribute.Integer & Attribute.Required & Attribute.Unique;
+    parent: Attribute.Relation<
+      'plugin::upload.folder',
+      'manyToOne',
+      'plugin::upload.folder'
+    >;
+    children: Attribute.Relation<
+      'plugin::upload.folder',
+      'oneToMany',
+      'plugin::upload.folder'
+    >;
+    files: Attribute.Relation<
+      'plugin::upload.folder',
+      'oneToMany',
+      'plugin::upload.file'
+    >;
+    path: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMax<{
+        min: 1;
+      }>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'plugin::upload.folder',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'plugin::upload.folder',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface PluginI18NLocale extends Schema.CollectionType {
+  collectionName: 'i18n_locale';
+  info: {
+    singularName: 'locale';
+    pluralName: 'locales';
+    collectionName: 'locales';
+    displayName: 'Locale';
+    description: '';
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  pluginOptions: {
+    'content-manager': {
+      visible: false;
+    };
+    'content-type-builder': {
+      visible: false;
+    };
+  };
+  attributes: {
+    name: Attribute.String &
+      Attribute.SetMinMax<{
+        min: 1;
+        max: 50;
+      }>;
+    code: Attribute.String & Attribute.Unique;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'plugin::i18n.locale',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'plugin::i18n.locale',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiAdDisclosureAdDisclosure extends Schema.CollectionType {
+  collectionName: 'ad_disclosures';
+  info: {
+    description: '';
+    displayName: 'Ad Disclosure';
+    pluralName: 'ad-disclosures';
+    singularName: 'ad-disclosure';
+  };
+  options: {
+    draftAndPublish: false;
+    populateCreatorFields: true;
+  };
+  attributes: {
+    adElection: Attribute.Enumeration<
+      ['Election 1', 'Election 2', 'Election 3']
+    > &
+      Attribute.Required;
+    adFormat: Attribute.Enumeration<
+      ['Digital', 'Print', 'Direct Mail', 'Tv', 'Radio']
+    > &
+      Attribute.Required;
+    adMedia: Attribute.Media & Attribute.Required;
+    adSpend: Attribute.Decimal & Attribute.Required;
+    adTextContent: Attribute.Text;
+    authorizedAdSpend: Attribute.Decimal;
+    candidatesMeasuresAndPoliticalParties: Attribute.DynamicZone<
+      [
+        'ad-disclosure.candidate',
+        'ad-disclosure.measure',
+        'ad-disclosure.political-party'
+      ]
+    > &
+      Attribute.Required;
+    clickCount: Attribute.Integer;
+    endDate: Attribute.Date & Attribute.Required;
+    externalLink: Attribute.String;
+    startDate: Attribute.Date & Attribute.Required;
+    targetAudience: Attribute.Text;
+    viewCount: Attribute.Integer;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::ad-disclosure.ad-disclosure',
+      'oneToOne',
+      'admin::user'
+    >;
+    updatedBy: Attribute.Relation<
+      'api::ad-disclosure.ad-disclosure',
+      'oneToOne',
+      'admin::user'
+    >;
+  };
+}
+
+export interface ApiFilingPeriodFilingPeriod extends Schema.CollectionType {
+  collectionName: 'filing_periods';
+  info: {
+    description: '';
+    displayName: 'Filing Period';
+    pluralName: 'filing-periods';
+    singularName: 'filing-period';
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  attributes: {
+    endDate: Attribute.Date & Attribute.Required;
+    name: Attribute.String & Attribute.Required & Attribute.Unique;
+    startDate: Attribute.Date & Attribute.Required;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::filing-period.filing-period',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::filing-period.filing-period',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiReportReport extends Schema.CollectionType {
+  collectionName: 'reports';
+  info: {
+    description: '';
+    displayName: 'Report';
+    pluralName: 'reports';
+    singularName: 'report';
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  attributes: {
+    adDisclosures: Attribute.String &
+      Attribute.CustomField<'plugin::ad-disclosure-report.ad-disclosure-table'>;
+    filingPeriod: Attribute.Relation<
+      'api::report.report',
+      'oneToOne',
+      'api::filing-period.filing-period'
+    >;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::report.report',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::report.report',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+declare module '@strapi/types' {
+  export module Shared {
+    export interface ContentTypes {
+      'admin::permission': AdminPermission;
+      'admin::user': AdminUser;
+      'admin::role': AdminRole;
+      'admin::api-token': AdminApiToken;
+      'admin::api-token-permission': AdminApiTokenPermission;
+      'admin::transfer-token': AdminTransferToken;
+      'admin::transfer-token-permission': AdminTransferTokenPermission;
+      'plugin::upload.file': PluginUploadFile;
+      'plugin::upload.folder': PluginUploadFolder;
+      'plugin::i18n.locale': PluginI18NLocale;
+      'api::ad-disclosure.ad-disclosure': ApiAdDisclosureAdDisclosure;
+      'api::filing-period.filing-period': ApiFilingPeriodFilingPeriod;
+      'api::report.report': ApiReportReport;
+    }
+  }
+}


### PR DESCRIPTION
# Overview

After deploying #18, an internal server error was discovered when indexing ad disclosures to Algolia. The error was caused by the `JSON.parse` call from within the `afterCreate` lifecycle hook. The thrown error was because the `adDisclosures` received in this context were of type `JSON` and not `string` causing the parsing to fail (because the custom field is registered as type `json`). This issue was not caught in local development, because changes were made to the `register` function while running in development with the `--watch-admin` flag. However, the plugin needs to be rebuilt when changes are made to the `register` function which is not apparent in the documentation. Removing the parsing in the `afterCreate` hook fixed the issue with the server error. However, removing the parsing and stringifying of the `JSON` within the custom field would not allow the report to be saved. There was also no indication of why the report would not save. The save button was enabled (so validation was passing), and no error was thrown. So, in order to fix this issue the path of least resistance was to change the field type from `json` to `string`. This fixes the issue with indexing to Algolia while still allowing reports to be saved.

## Testing locally
* Run `yarn build` to rebuild the Strapi admin and plugin
* Test that saving reports indexes related ad disclosures to Algolia

## Bonus

This PR also fixes some TypeScript errors within the plugin and adds proper schema type definitions for Strapi.

## Task
[CLCAD-40](https://maplight.atlassian.net/browse/CLCAD-40)

[CLCAD-40]: https://maplight.atlassian.net/browse/CLCAD-40?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ