### PR TITLE
[FEATURE] Require Candidates, Measures, and/or Parties CLCAD-62

### DIFF
--- a/backend/src/api/ad-disclosure/content-types/ad-disclosure/schema.json
+++ b/backend/src/api/ad-disclosure/content-types/ad-disclosure/schema.json
@@ -47,6 +47,7 @@
         "ad-disclosure.measure",
         "ad-disclosure.political-party"
       ],
+      "min": 1,
       "required": true,
       "type": "dynamiczone"
     },

--- a/backend/types/generated/contentTypes.d.ts
+++ b/backend/types/generated/contentTypes.d.ts
@@ -558,7 +558,10 @@ export interface ApiAdDisclosureAdDisclosure extends Schema.CollectionType {
         'ad-disclosure.political-party'
       ]
     > &
-      Attribute.Required;
+      Attribute.Required &
+      Attribute.SetMinMax<{
+        min: 1;
+      }>;
     clickCount: Attribute.Integer;
     endDate: Attribute.Date & Attribute.Required;
     externalLink: Attribute.String;


### PR DESCRIPTION
# Overview

Requires filers to add at least one candidate, measure, or political party when creating an ad disclosure.

## Task
[CLCAD-62](https://maplight.atlassian.net/browse/CLCAD-62)

[CLCAD-62]: https://maplight.atlassian.net/browse/CLCAD-62?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ