### PR TITLE
[FEATURE] Ad disclosure fields for reports CLCAD-58

### DIFF
--- a/backend/src/plugins/ad-disclosure-report/admin/src/components/AdDisclosureTable/index.tsx
+++ b/backend/src/plugins/ad-disclosure-report/admin/src/components/AdDisclosureTable/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import type { ReactElement } from "react";
+import { useHistory } from "react-router-dom";
 import {
   Box,
   EmptyStateLayout,
@@ -15,6 +16,11 @@ import { useCMEditViewDataManager } from "@strapi/helper-plugin";
 import useAdDisclosureReportData from "../../hooks/use-ad-disclosure-report-data";
 import useIsAdmin from "../../hooks/use-is-admin";
 import type { ApiAdDisclosureAdDisclosure } from "../../../../../../../types/generated/contentTypes";
+import styled from "styled-components";
+
+const TableRow = styled(Tr)({
+  cursor: "pointer",
+});
 
 type AdDisclosure = ApiAdDisclosureAdDisclosure & {
   id: number;
@@ -26,6 +32,7 @@ const AdDisclosureTable = ({
   onChange,
   value,
 }): ReactElement => {
+  const history = useHistory();
   const { fetchAdDisclosures, fetchFilingPeriod } = useAdDisclosureReportData();
   const isAdmin = useIsAdmin();
 
@@ -92,7 +99,14 @@ const AdDisclosureTable = ({
             adDisclosures?.map((adDisclosure) => {
               const { attributes, id } = adDisclosure;
               return (
-                <Tr key={id}>
+                <TableRow
+                  key={id}
+                  onClick={() =>
+                    history.push(
+                      `/content-manager/collectionType/api::ad-disclosure.ad-disclosure/${id}`
+                    )
+                  }
+                >
                   <Td>
                     <Typography textColor="neutral800">{id}</Typography>
                   </Td>
@@ -106,7 +120,7 @@ const AdDisclosureTable = ({
                       {attributes.adSpend}
                     </Typography>
                   </Td>
-                </Tr>
+                </TableRow>
               );
             })
           ) : (

--- a/backend/src/plugins/ad-disclosure-report/admin/src/components/AdDisclosureTable/index.tsx
+++ b/backend/src/plugins/ad-disclosure-report/admin/src/components/AdDisclosureTable/index.tsx
@@ -80,13 +80,10 @@ const AdDisclosureTable = ({
               <Typography variant="sigma">ID</Typography>
             </Th>
             <Th>
-              <Typography variant="sigma">Ad Format</Typography>
+              <Typography variant="sigma">Ad Election</Typography>
             </Th>
             <Th>
               <Typography variant="sigma">Ad Spend</Typography>
-            </Th>
-            <Th>
-              <Typography variant="sigma">Target Audience</Typography>
             </Th>
           </Tr>
         </Thead>
@@ -101,17 +98,12 @@ const AdDisclosureTable = ({
                   </Td>
                   <Td>
                     <Typography textColor="neutral800">
-                      {attributes.adFormat}
+                      {attributes.adElection}
                     </Typography>
                   </Td>
                   <Td>
                     <Typography textColor="neutral800">
                       {attributes.adSpend}
-                    </Typography>
-                  </Td>
-                  <Td>
-                    <Typography textColor="neutral800">
-                      {attributes.targetAudience}
                     </Typography>
                   </Td>
                 </Tr>

--- a/backend/src/plugins/ad-disclosure-report/admin/src/components/AdDisclosureTable/index.tsx
+++ b/backend/src/plugins/ad-disclosure-report/admin/src/components/AdDisclosureTable/index.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react';
-import type { ReactElement } from 'react';
+import React, { useEffect, useState } from "react";
+import type { ReactElement } from "react";
 import {
   Box,
   EmptyStateLayout,
@@ -10,26 +10,27 @@ import {
   Thead,
   Tr,
   Typography,
-} from '@strapi/design-system';
-import {
-  useCMEditViewDataManager,
-} from '@strapi/helper-plugin';
-import useAdDisclosureReportData from '../../hooks/use-ad-disclosure-report-data';
-import useIsAdmin from '../../hooks/use-is-admin';
-import type { ApiAdDisclosureAdDisclosure } from '../../../../../../../types/generated/contentTypes';
+} from "@strapi/design-system";
+import { useCMEditViewDataManager } from "@strapi/helper-plugin";
+import useAdDisclosureReportData from "../../hooks/use-ad-disclosure-report-data";
+import useIsAdmin from "../../hooks/use-is-admin";
+import type { ApiAdDisclosureAdDisclosure } from "../../../../../../../types/generated/contentTypes";
 
 type AdDisclosure = ApiAdDisclosureAdDisclosure & {
   id: number;
-}
+};
 
-const AdDisclosureTable = ({ attribute,  name, onChange, value }): ReactElement => {
+const AdDisclosureTable = ({
+  attribute,
+  name,
+  onChange,
+  value,
+}): ReactElement => {
   const { fetchAdDisclosures, fetchFilingPeriod } = useAdDisclosureReportData();
   const isAdmin = useIsAdmin();
 
   const {
-    modifiedData:  {
-      filingPeriod: modifiedFilingPeriod,
-    },
+    modifiedData: { filingPeriod: modifiedFilingPeriod },
   } = useCMEditViewDataManager();
 
   const [adDisclosures, setAdDisclosures] = useState<AdDisclosure[]>(
@@ -38,7 +39,7 @@ const AdDisclosureTable = ({ attribute,  name, onChange, value }): ReactElement 
 
   const handleChange = (value: string) => {
     onChange({ target: { name, value, type: attribute.type } });
-  }
+  };
 
   const populateAdDisclosures = async (selectedFilingPeriodId: number) => {
     const filingPeriod = await fetchFilingPeriod(selectedFilingPeriodId);
@@ -53,7 +54,7 @@ const AdDisclosureTable = ({ attribute,  name, onChange, value }): ReactElement 
         setAdDisclosures(adDisclosures);
       }
     }
-  }
+  };
 
   useEffect(() => {
     // Don't fetch ad disclosures if user is an admin
@@ -90,37 +91,46 @@ const AdDisclosureTable = ({ attribute,  name, onChange, value }): ReactElement 
           </Tr>
         </Thead>
         <Tbody>
-          {adDisclosures.length > 0 ? adDisclosures?.map(adDisclosure => {
-            const { attributes, id } = adDisclosure;
-            return (
-              <Tr key={id}>
-                <Td>
-                  <Typography textColor="neutral800">{id}</Typography>
-                </Td>
-                <Td>
-                <Typography textColor="neutral800">{attributes.adFormat}</Typography>
-                </Td>
-                <Td>
-                  <Typography textColor="neutral800">{attributes.adSpend}</Typography>
-                </Td>
-                <Td>
-                  <Typography textColor="neutral800">{attributes.targetAudience}</Typography>
-                </Td>
-              </Tr>
-            )}) : (
-              <Tr>
-                <Td colSpan={4}>
-                  <EmptyStateLayout
-                    content="Select a Filing Period to view Ad Disclosures."
-                    shadow="none"
-                  />
-                </Td>
-              </Tr>
-            )}
+          {adDisclosures.length > 0 ? (
+            adDisclosures?.map((adDisclosure) => {
+              const { attributes, id } = adDisclosure;
+              return (
+                <Tr key={id}>
+                  <Td>
+                    <Typography textColor="neutral800">{id}</Typography>
+                  </Td>
+                  <Td>
+                    <Typography textColor="neutral800">
+                      {attributes.adFormat}
+                    </Typography>
+                  </Td>
+                  <Td>
+                    <Typography textColor="neutral800">
+                      {attributes.adSpend}
+                    </Typography>
+                  </Td>
+                  <Td>
+                    <Typography textColor="neutral800">
+                      {attributes.targetAudience}
+                    </Typography>
+                  </Td>
+                </Tr>
+              );
+            })
+          ) : (
+            <Tr>
+              <Td colSpan={4}>
+                <EmptyStateLayout
+                  content="Select a Filing Period to view Ad Disclosures."
+                  shadow="none"
+                />
+              </Td>
+            </Tr>
+          )}
         </Tbody>
       </Table>
     </Box>
-  )
-}
+  );
+};
 
 export default AdDisclosureTable;


### PR DESCRIPTION
# Overview

Updates the fields listed in the ad disclosure table to include:

* ID
* Ad Election
* Ad Spend

## Bonus

Updates the table rows to navigate to the ad disclosure on click.

## Screenshot
<img width="1164" alt="Content Manager 2023-10-25 13-02-13" src="https://github.com/maplight/clc-ad-transparency/assets/38389357/ef28fd55-9fe8-4a22-88eb-06ae4073c381">

## Task
[CLCAD-58](https://maplight.atlassian.net/browse/CLCAD-58)

[CLCAD-58]: https://maplight.atlassian.net/browse/CLCAD-58?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ