### PR TITLE
[BUGFIX] 500 internal server error CLCAD-64

### DIFF
--- a/backend/src/plugins/ad-disclosure-report/admin/src/index.tsx
+++ b/backend/src/plugins/ad-disclosure-report/admin/src/index.tsx
@@ -1,27 +1,28 @@
-import { prefixPluginTranslations } from '@strapi/helper-plugin';
-import AdDisclosureTableIcon from './components/AdDisclosureTable/AdDisclosureTableIcon';
-import getTrad from './utils/getTrad';
-import pluginId from './pluginId';
+import { prefixPluginTranslations } from "@strapi/helper-plugin";
+import AdDisclosureTableIcon from "./components/AdDisclosureTable/AdDisclosureTableIcon";
+import getTrad from "./utils/getTrad";
+import pluginId from "./pluginId";
 
 export default {
   register(app: any) {
     app.customFields.register({
-      name: 'ad-disclosure-table',
-      pluginId: 'ad-disclosure-report',
-      type: 'string',
+      name: "ad-disclosure-table",
+      pluginId: "ad-disclosure-report",
+      type: "string",
       icon: AdDisclosureTableIcon,
       intlLabel: {
-        id: getTrad('ad-disclosure-table.label'),
-        defaultMessage: 'Ad Disclosure Table',
+        id: getTrad("ad-disclosure-table.label"),
+        defaultMessage: "Ad Disclosure Table",
       },
       intlDescription: {
-        id: getTrad('ad-disclosure-table.description'),
-        defaultMessage: 'Display a table of ad disclosures for a filing period.',
+        id: getTrad("ad-disclosure-table.description"),
+        defaultMessage:
+          "Display a table of ad disclosures for a filing period.",
       },
       components: {
         Input: async () =>
           import(
-            /* webpackChunkName: 'ad-disclosure-table-component' */ './components/AdDisclosureTable'
+            /* webpackChunkName: 'ad-disclosure-table-component' */ "./components/AdDisclosureTable"
           ),
       },
     });

--- a/backend/src/plugins/ad-disclosure-report/admin/src/index.tsx
+++ b/backend/src/plugins/ad-disclosure-report/admin/src/index.tsx
@@ -8,7 +8,7 @@ export default {
     app.customFields.register({
       name: "ad-disclosure-table",
       pluginId: "ad-disclosure-report",
-      type: "string",
+      type: "text",
       icon: AdDisclosureTableIcon,
       intlLabel: {
         id: getTrad("ad-disclosure-table.label"),

--- a/backend/src/plugins/ad-disclosure-report/server/register.ts
+++ b/backend/src/plugins/ad-disclosure-report/server/register.ts
@@ -4,7 +4,7 @@ export default ({ strapi }: { strapi: Strapi }) => {
   strapi.customFields.register({
     name: "ad-disclosure-table",
     plugin: "ad-disclosure-report",
-    type: "string",
+    type: "text",
     inputSize: {
       default: 4,
       isResizable: true,

--- a/backend/types/generated/contentTypes.d.ts
+++ b/backend/types/generated/contentTypes.d.ts
@@ -627,7 +627,7 @@ export interface ApiReportReport extends Schema.CollectionType {
     draftAndPublish: false;
   };
   attributes: {
-    adDisclosures: Attribute.String &
+    adDisclosures: Attribute.Text &
       Attribute.CustomField<'plugin::ad-disclosure-report.ad-disclosure-table'>;
     filingPeriod: Attribute.Relation<
       'api::report.report',


### PR DESCRIPTION
# Overview

After merging #19 to production, I began testing the indexing to Algolia and saw another 500 server error occurring. Digging into the Strapi runtime logs presented a clue to what was going on:

```
[2023-10-25 20:27:48] [2023-10-25 20:27:48.294] error: insert into "public"."reports" ("ad_disclosures", "created_at", "created_by_id", "updated_at", "updated_by_id") values ($1, $2, $3, $4, $5) returning "id" - value too long for type character varying(255)
[2023-10-25 20:27:48] error: insert into "public"."reports" ("ad_disclosures", "created_at", "created_by_id", "updated_at", "updated_by_id") values ($1, $2, $3, $4, $5) returning "id" - value too long for type character varying(255)
```

After looking through some [GitHub issues](https://github.com/strapi/strapi/issues/12130), I realized that the default Postgres database used for Strapi Cloud has a 255 character limit set on `string` columns. This error didn't surface in development because the dev instance is running with a basic SQLite database for simplicity. Changing the data type used here will force the column to use `text` as the type, which by default has no character limit. We'll probably want to update the dev instance to use Postgres so that we can catch such errors before they make it to production.

## TODO
- [ ] Verify that reports are able to be created after merging to prod

## Task
[CLCAD-64](https://maplight.atlassian.net/browse/CLCAD-64)

[CLCAD-64]: https://maplight.atlassian.net/browse/CLCAD-64?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ