### PR TITLE
[FEATURE] Add initial filters for public search CLCAD-19

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -14,6 +14,7 @@ adDisclosuresIndex.setSettings({
   attributesForFaceting: [
     "adElection",
     "adFormat",
+    "afterDistinct(searchable(createdBy))",
   ],
   searchableAttributes: ["adTextContent"],
 });
@@ -66,14 +67,20 @@ export default {
             filters: {
               id: reportAdDisclosureIds,
             },
+            populate: [
+              "createdBy",
+            ],
           }
         );
 
         const adDisclosureObjects = adDisclosures.map(
-          ({ id, ...adDisclosure }) => ({
-            objectID: id,
-            ...adDisclosure,
-          })
+          ({ id, ...adDisclosure }) => {
+            return {
+              objectID: id,
+              ...adDisclosure,
+              createdBy: `${adDisclosure.createdBy.firstname} ${adDisclosure.createdBy.lastname}`,
+            };
+          }
         );
 
         try {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -17,6 +17,7 @@ adDisclosuresIndex.setSettings({
   attributesForFaceting: [
     "adElection",
     "adFormat",
+    "adSpend",
     "afterDistinct(searchable(createdBy))",
     "candidates.lvl0",
     "candidates.lvl1",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,6 +2,9 @@ import algoliaClient from "./utils/algolia-client";
 import clearData from "./utils/clear-data";
 import generateAdDisclosureData from "./utils/generate-ad-disclosure-data";
 import generateFilingPeriodData from "./utils/generate-filing-period-data";
+import type { Attribute } from "@strapi/strapi";
+
+type AdDisclosure = Attribute.GetValues<"api::ad-disclosure.ad-disclosure">;
 
 const AD_DISCLOSURE_MODEL_UID = "api::ad-disclosure.ad-disclosure";
 const REPORT_MODEL_UID = "api::report.report";
@@ -15,9 +18,34 @@ adDisclosuresIndex.setSettings({
     "adElection",
     "adFormat",
     "afterDistinct(searchable(createdBy))",
+    "candidates.lvl0",
+    "candidates.lvl1",
+    "measures.lvl0",
+    "measures.lvl1",
+    "politicalParties.lvl0",
+    "politicalParties.lvl1",
   ],
   searchableAttributes: ["adTextContent"],
 });
+
+const getValuesByComponent = (
+  candidatesMeasuresAndPoliticalParties: AdDisclosure["candidatesMeasuresAndPoliticalParties"],
+  component: AdDisclosure["candidatesMeasuresAndPoliticalParties"][number]["__component"]
+) =>
+  candidatesMeasuresAndPoliticalParties.filter(
+    ({ __component }) => __component === component
+  );
+
+const lvl0FacetValues = ({
+  name,
+}: AdDisclosure["candidatesMeasuresAndPoliticalParties"][number]) => name;
+
+const lvl1FacetValues = ({
+  name,
+  stance,
+}: AdDisclosure["candidatesMeasuresAndPoliticalParties"][number]) =>
+  `${name} > ${stance}`;
+
 export default {
   /**
    * An asynchronous register function that runs before
@@ -68,6 +96,7 @@ export default {
               id: reportAdDisclosureIds,
             },
             populate: [
+              "candidatesMeasuresAndPoliticalParties",
               "createdBy",
             ],
           }
@@ -75,9 +104,32 @@ export default {
 
         const adDisclosureObjects = adDisclosures.map(
           ({ id, ...adDisclosure }) => {
+            const { candidatesMeasuresAndPoliticalParties } = adDisclosure;
+
+            const candidates = getValuesByComponent(
+              candidatesMeasuresAndPoliticalParties,
+              "ad-disclosure.candidate"
+            );
+
+            const measures = getValuesByComponent(
+              candidatesMeasuresAndPoliticalParties,
+              "ad-disclosure.measure"
+            );
+
+            const politicalParties = getValuesByComponent(
+              candidatesMeasuresAndPoliticalParties,
+              "ad-disclosure.political-party"
+            );
+
             return {
               objectID: id,
               ...adDisclosure,
+              "candidates.lvl0": candidates.map(lvl0FacetValues),
+              "candidates.lvl1": candidates.map(lvl1FacetValues),
+              "measures.lvl0": measures.map(lvl0FacetValues),
+              "measures.lvl1": measures.map(lvl1FacetValues),
+              "politicalParties.lvl0": politicalParties.map(lvl0FacetValues),
+              "politicalParties.lvl1": politicalParties.map(lvl1FacetValues),
               createdBy: `${adDisclosure.createdBy.firstname} ${adDisclosure.createdBy.lastname}`,
             };
           }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -10,6 +10,13 @@ const adDisclosuresIndex = algoliaClient.initIndex(
   `ad_disclosures_${process.env.NODE_ENV}`
 );
 
+adDisclosuresIndex.setSettings({
+  attributesForFaceting: [
+    "adElection",
+    "adFormat",
+  ],
+  searchableAttributes: ["adTextContent"],
+});
 export default {
   /**
    * An asynchronous register function that runs before

--- a/frontend/app/components/MenuSelect/index.tsx
+++ b/frontend/app/components/MenuSelect/index.tsx
@@ -1,0 +1,26 @@
+import type { UseMenuProps } from "react-instantsearch";
+import { useMenu } from "react-instantsearch";
+
+const MenuSelect = (props: UseMenuProps) => {
+  const { items, refine } = useMenu(props);
+  const { value: selectedValue } = items.find((item) => item.isRefined) || {
+    value: "",
+  };
+
+  return (
+    <select
+      value={selectedValue}
+      onChange={(event) => {
+        refine((event.target as HTMLSelectElement).value);
+      }}
+    >
+      {items.map((item, index) => (
+        <option key={index} value={item.value}>
+          {item.label}
+        </option>
+      ))}
+    </select>
+  );
+};
+
+export default MenuSelect;

--- a/frontend/app/components/NumericMenu/index.tsx
+++ b/frontend/app/components/NumericMenu/index.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { useNumericMenu, type UseNumericMenuProps } from "react-instantsearch";
+
+const NumericMenu = (props: UseNumericMenuProps) => {
+  const { items, refine } = useNumericMenu(props);
+
+  return (
+    <ul>
+      {items.map((item) => (
+        <li key={item.value}>
+          <label>
+            <input
+              type="radio"
+              name={item.label}
+              checked={item.isRefined}
+              onChange={() => {
+                refine(item.value);
+              }}
+            />
+            <span>{item.label}</span>
+          </label>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default NumericMenu;

--- a/frontend/app/routes/_index.tsx
+++ b/frontend/app/routes/_index.tsx
@@ -15,6 +15,7 @@ import { useLoaderData } from "@remix-run/react";
 import { history } from "instantsearch.js/cjs/lib/routers/index.js";
 import searchClient from "~/search-client";
 import MenuSelect from "~/components/MenuSelect";
+import NumericMenu from "~/components/NumericMenu";
 
 import "instantsearch.css/themes/satellite.css";
 
@@ -58,6 +59,17 @@ const Search = ({ serverState, serverUrl }: SearchProps) => {
           searchable
           sortBy={["count:desc", "name:asc", "isRefined:asc"]}
         />
+        <h2>Ad Spend</h2>
+        <NumericMenu
+          attribute="adSpend"
+          items={[
+            { label: "Any", start: 0 },
+            { label: "$1,000+", start: 1000 },
+            { label: "$10,000+", start: 10000 },
+            { label: "$100,000+", start: 100000 },
+            { label: "$1,000,000+", start: 1000000 },
+          ]}
+        />
         <h2>Candidate</h2>
         <HierarchicalMenu attributes={["candidates.lvl0", "candidates.lvl1"]} />
         <h2>Measure</h2>
@@ -98,6 +110,7 @@ export default function Index() {
   const { serverState, serverUrl } = useLoaderData() as SearchProps;
   return (
     <div>
+      <h1>Search for Ad Disclosures</h1>
       <Search serverState={serverState} serverUrl={serverUrl} />
     </div>
   );

--- a/frontend/app/routes/_index.tsx
+++ b/frontend/app/routes/_index.tsx
@@ -4,6 +4,7 @@ import { type LoaderFunction, type MetaFunction, json } from "@vercel/remix";
 import {
   InstantSearch,
   InstantSearchSSRProvider,
+  Menu,
   SearchBox,
   getServerState,
   Hits,
@@ -11,6 +12,7 @@ import {
 import { useLoaderData } from "@remix-run/react";
 import { history } from "instantsearch.js/cjs/lib/routers/index.js";
 import searchClient from "~/search-client";
+import MenuSelect from "~/components/MenuSelect";
 
 import "instantsearch.css/themes/satellite.css";
 
@@ -38,6 +40,16 @@ const Search = ({ serverState, serverUrl }: SearchProps) => {
         }}
       >
         <SearchBox />
+        <h2>Election</h2>
+        <Menu
+          attribute="adElection"
+          sortBy={["count:desc", "name:asc", "isRefined:asc"]}
+        />
+        <h2>Format</h2>
+        <MenuSelect
+          attribute="adFormat"
+          sortBy={["count:desc", "name:asc", "isRefined:asc"]}
+        />
         <Hits />
       </InstantSearch>
     </InstantSearchSSRProvider>

--- a/frontend/app/routes/_index.tsx
+++ b/frontend/app/routes/_index.tsx
@@ -2,13 +2,14 @@ import { renderToString } from "react-dom/server";
 import type { InstantSearchServerState } from "react-instantsearch";
 import { type LoaderFunction, type MetaFunction, json } from "@vercel/remix";
 import {
+  getServerState,
+  HierarchicalMenu,
+  Hits,
   InstantSearch,
   InstantSearchSSRProvider,
   Menu,
   RefinementList,
   SearchBox,
-  getServerState,
-  Hits,
 } from "react-instantsearch";
 import { useLoaderData } from "@remix-run/react";
 import { history } from "instantsearch.js/cjs/lib/routers/index.js";
@@ -56,6 +57,14 @@ const Search = ({ serverState, serverUrl }: SearchProps) => {
           attribute="createdBy"
           searchable
           sortBy={["count:desc", "name:asc", "isRefined:asc"]}
+        />
+        <h2>Candidate</h2>
+        <HierarchicalMenu attributes={["candidates.lvl0", "candidates.lvl1"]} />
+        <h2>Measure</h2>
+        <HierarchicalMenu attributes={["measures.lvl0", "measures.lvl1"]} />
+        <h2>Party</h2>
+        <HierarchicalMenu
+          attributes={["politicalParties.lvl0", "politicalParties.lvl1"]}
         />
         <Hits />
       </InstantSearch>

--- a/frontend/app/routes/_index.tsx
+++ b/frontend/app/routes/_index.tsx
@@ -5,6 +5,7 @@ import {
   InstantSearch,
   InstantSearchSSRProvider,
   Menu,
+  RefinementList,
   SearchBox,
   getServerState,
   Hits,
@@ -48,6 +49,12 @@ const Search = ({ serverState, serverUrl }: SearchProps) => {
         <h2>Format</h2>
         <MenuSelect
           attribute="adFormat"
+          sortBy={["count:desc", "name:asc", "isRefined:asc"]}
+        />
+        <h2>Filer</h2>
+        <RefinementList
+          attribute="createdBy"
+          searchable
           sortBy={["count:desc", "name:asc", "isRefined:asc"]}
         />
         <Hits />


### PR DESCRIPTION
# Depends on #26 for data generation

# Overview

This PR extends the frontend capabilities of the Algolia search by providing filtering options for the following fields:

* `adElection`
* `adFormat`
* `adSpend`
* `createdBy`
* `candidatesMeasuresAndPoliticalParties`

## TODO

- [x] Switch base branch after #26 is merged

## Screen recording

https://github.com/maplight/clc-ad-transparency/assets/38389357/efd84a0b-8310-4bcc-9ca3-435c84383ef8

## Tasks
[CLCAD-7](https://maplight.atlassian.net/browse/CLCAD-7)
[CLCAD-17](https://maplight.atlassian.net/browse/CLCAD-17)
[CLCAD-19](https://maplight.atlassian.net/browse/CLCAD-19)
[CLCAD-20](https://maplight.atlassian.net/browse/CLCAD-20)
[CLCAD-21](https://maplight.atlassian.net/browse/CLCAD-21)
[CLCAD-31](https://maplight.atlassian.net/browse/CLCAD-31)


[CLCAD-7]: https://maplight.atlassian.net/browse/CLCAD-7?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLCAD-17]: https://maplight.atlassian.net/browse/CLCAD-17?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLCAD-19]: https://maplight.atlassian.net/browse/CLCAD-19?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLCAD-20]: https://maplight.atlassian.net/browse/CLCAD-20?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLCAD-21]: https://maplight.atlassian.net/browse/CLCAD-21?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLCAD-31]: https://maplight.atlassian.net/browse/CLCAD-31?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ