### PR TITLE
[BUGFIX] File uploads for demo data generation CLCAD-38

### DIFF
--- a/backend/src/utils/upload-ad-disclosure-media.ts
+++ b/backend/src/utils/upload-ad-disclosure-media.ts
@@ -30,24 +30,24 @@ const uploadAdDisclosureMedia = async (strapi: Strapi, currentUser: User) => {
   const mediaUploads = [];
 
   for (const filename of adDisclosureMediaFilenames) {
+    const hash = faker.string.uuid();
+    const mimeType = mime.getType(filename);
+    const ext = mime.getExtension(mimeType);
+
     const mediaUpload = uploadFile(
       strapi,
       {
-        data: {
-          refId: Date.now().toString(),
-          ref: "api::ad-disclosure.ad-disclosure",
-          field: "adMedia",
-        },
-        file: {
-          path: join(
-            __dirname,
-            "../../../public/ad-disclosure-media",
-            randomAdDisclosureMediaDirectory,
-            filename
-          ),
-          name: `${faker.string.uuid()}--${filename}`,
-          type: mime.getType(filename),
-        },
+        ext,
+        hash,
+        mime: mimeType,
+        name: `${hash}--${filename}`,
+        path: join(
+          __dirname,
+          "../../../public/ad-disclosure-media",
+          randomAdDisclosureMediaDirectory,
+          filename
+        ),
+        url: `/ad-disclosure-media/${randomAdDisclosureMediaDirectory}/${filename}`,
       },
       currentUser
     );


### PR DESCRIPTION
# Overview

After testing and merging #26, the [deployment failed](https://cloud.strapi.io/projects/clc-ad-transparency-99273c2e21/deployments/3f869d3e-b8d6-4bab-8c5b-ac71c46641dd) during the file upload process. The error is rather opaque, and only indicates that we are getting a `401` for `Invalid credentials`. This update is an attempt at fixing this error by converting the upload process to use Strapi's Entity Service API instead of interacting with the upload plugin directly. The demo data generation was successful in creating `filingPeriods`, which is also using the Entity Service API. My hope is that this change will allow us to get past this error. While Strapi Cloud does not support multiple environments, we should probably think about what a staging environment would look like for this app, so that we can fully test these types of changes before going into production.

## Task
[CLCAD-38](https://maplight.atlassian.net/browse/CLCAD-38)

[CLCAD-38]: https://maplight.atlassian.net/browse/CLCAD-38?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ