### PR TITLE
[FEATURE] Date filtering CLCAD-18

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -4,6 +4,7 @@ import generateAdDisclosureData from "./utils/generate-ad-disclosure-data";
 import generateFilingPeriodData from "./utils/generate-filing-period-data";
 import type { Attribute } from "@strapi/strapi";
 import { errors } from "@strapi/utils";
+import { parseISO } from "date-fns";
 
 type AdDisclosure = Attribute.GetValues<"api::ad-disclosure.ad-disclosure">;
 
@@ -27,6 +28,8 @@ adDisclosuresIndex.setSettings({
     "measures.lvl1",
     "politicalParties.lvl0",
     "politicalParties.lvl1",
+    "startDateTimestamp",
+    "endDateTimestamp",
   ],
   searchableAttributes: ["adTextContent"],
 });
@@ -146,6 +149,8 @@ export default {
               "politicalParties.lvl0": politicalParties.map(lvl0FacetValues),
               "politicalParties.lvl1": politicalParties.map(lvl1FacetValues),
               filerName: registration.filerName,
+              startDateTimestamp: parseISO(adDisclosure.startDate).getTime(),
+              endDateTimestamp: parseISO(adDisclosure.endDate).getTime(),
             };
           }
         );

--- a/frontend/app/components/AdDisclosureCard/index.tsx
+++ b/frontend/app/components/AdDisclosureCard/index.tsx
@@ -8,6 +8,7 @@ import Format from "./Format";
 import type { ReactElement } from "react";
 import type { Hit } from "instantsearch.js";
 import { Highlight } from "react-instantsearch";
+import { format, parseISO } from "date-fns";
 
 type Props = {
   hit: Hit;
@@ -32,7 +33,21 @@ const AdDisclosureCard = ({ hit }: Props): ReactElement => {
         <div className="lg:max-w-lg lg:self-end">
           <div className="flex items-center space-x-2">
             <div className="flex items-center text-sm">
-              <p className="font-medium text-gray-500">{hit.adElection}</p>
+              <p className="font-light text-gray-500">{hit.adElection}</p>
+            </div>
+            <svg
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              aria-hidden="true"
+              className="ml-2 h-5 w-5 flex-shrink-0 text-gray-300"
+            >
+              <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+            </svg>
+            <div className="flex items-center text-sm">
+              <p className="font-light text-gray-500">{`${format(
+                parseISO(hit.startDate),
+                "MMM d, yyyy"
+              )} — ${format(parseISO(hit.endDate), "MMM d, yyyy")}`}</p>
             </div>
           </div>
 

--- a/frontend/app/components/AdDisclosureTable/index.tsx
+++ b/frontend/app/components/AdDisclosureTable/index.tsx
@@ -2,6 +2,7 @@ import { useHits } from "react-instantsearch";
 import type { Hit } from "instantsearch.js";
 import type { ReactElement } from "react";
 import Target from "~/components/Target";
+import { format, parseISO } from "date-fns";
 
 const STRAPI_BASE_URL =
   process.env.NODE_ENV === "production"
@@ -34,18 +35,10 @@ const TableRow = ({ hit }: { hit: Hit }): ReactElement => {
         </div>
       </td>
       <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-        {new Intl.DateTimeFormat("en-US", {
-          year: "numeric",
-          month: "long",
-          day: "numeric",
-        }).format(new Date(hit.startDate))}
+        {format(parseISO(hit.startDate), "MMM d, yyyy")}
       </td>
       <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-        {new Intl.DateTimeFormat("en-US", {
-          year: "numeric",
-          month: "long",
-          day: "numeric",
-        }).format(new Date(hit.endDate))}
+        {format(parseISO(hit.endDate), "MMM d, yyyy")}
       </td>
       <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
         {`$${new Intl.NumberFormat().format(hit.adSpend)}`}

--- a/frontend/app/components/DateSelect/index.tsx
+++ b/frontend/app/components/DateSelect/index.tsx
@@ -1,0 +1,87 @@
+import type { ReactElement } from "react";
+import { CalendarIcon } from "@heroicons/react/24/outline";
+import ReactDatePicker from "react-datepicker";
+import { useRange } from "react-instantsearch";
+import { useState, useEffect } from "react";
+
+import "react-datepicker/dist/react-datepicker.css";
+
+const DatePicker =
+  (ReactDatePicker as unknown as { default: typeof ReactDatePicker }).default ??
+  ReactDatePicker;
+
+const DateSelect = (): ReactElement => {
+  const { range, refine, start } = useRange({
+    attribute: "endDateTimestamp",
+  });
+
+  const { min, max } = range;
+
+  const [from, setFrom] = useState(min);
+  const [to, setTo] = useState(max);
+
+  const refineEndDate = (fromDate: Date | null, toDate: Date | null) => {
+    // Convert to Unix timestamp before refining
+    const min = fromDate ? fromDate.getTime() : undefined;
+    const max = toDate ? toDate.getTime() : undefined;
+    refine([min, max]);
+  };
+
+  const handleFromDateChange = (date: Date | null) => {
+    if (to && date && date.getTime() > to) {
+      refineEndDate(date ?? null, null);
+    } else {
+      refineEndDate(date ?? null, to ? new Date(to) : null);
+    }
+  };
+
+  const handleToDateChange = (date: Date | null) => {
+    if (from && date && date.getTime() < from) {
+      refineEndDate(null, date);
+    } else {
+      refineEndDate(from ? new Date(from) : null, date);
+    }
+  };
+  const rangeFrom = Math.max(
+    Number(min),
+    Number.isFinite(Number(start[0])) ? Number(start[0]) : Number(min)
+  );
+  const rangeTo = Math.min(
+    Number(max),
+    Number.isFinite(Number(start[1])) ? Number(start[1]) : Number(max)
+  );
+
+  useEffect(() => {
+    setFrom(rangeFrom);
+    setTo(rangeTo);
+  }, [rangeFrom, rangeTo]);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <label className="block text-sm font-medium text-gray-700">From</label>
+      <DatePicker
+        className="block h-full w-full border-0 py-2 pr-0 text-gray-900 placeholder:text-gray-400 ring-1 ring-primary-500 focus:ring-2 focus:ring-primary-600 sm:text-sm rounded"
+        icon={<CalendarIcon className="h-3 w-3" />}
+        showIcon
+        minDate={min ? new Date(min) : undefined}
+        maxDate={max ? new Date(max) : undefined}
+        selected={from ? new Date(from) : undefined}
+        onChange={handleFromDateChange}
+        withPortal
+      />
+      <label className="block text-sm font-medium text-gray-700">To</label>
+      <DatePicker
+        className="block h-full w-full border-0 py-2 pr-0 text-gray-900 placeholder:text-gray-400 ring-1 ring-primary-500 focus:ring-2 focus:ring-primary-600 sm:text-sm rounded"
+        icon={<CalendarIcon className="h-3 w-3" />}
+        showIcon
+        minDate={from ? new Date(from) : undefined}
+        maxDate={max ? new Date(max) : undefined}
+        selected={to ? new Date(to) : undefined}
+        onChange={handleToDateChange}
+        withPortal
+      />
+    </div>
+  );
+};
+
+export default DateSelect;

--- a/frontend/app/components/Search/FiltersSidebar/SearchFilters/index.tsx
+++ b/frontend/app/components/Search/FiltersSidebar/SearchFilters/index.tsx
@@ -1,6 +1,7 @@
 import { HierarchicalMenu, Menu, RefinementList } from "react-instantsearch";
 import MenuSelect from "~/components/MenuSelect";
 import NumericMenu from "~/components/NumericMenu";
+import DateSelect from "~/components/DateSelect";
 import Card from "~/components/Card";
 
 const SearchFilters = () => {
@@ -84,6 +85,11 @@ const SearchFilters = () => {
             }}
             sortBy={["count:desc", "name:asc", "isRefined:asc"]}
           />
+        </Card>
+      </li>
+      <li>
+        <Card title="Date">
+          <DateSelect />
         </Card>
       </li>
     </ul>

--- a/frontend/app/components/Search/SearchBar/index.tsx
+++ b/frontend/app/components/Search/SearchBar/index.tsx
@@ -10,7 +10,7 @@ type Props = {
 
 const SearchBar = ({ setView, view }: Props): ReactElement => {
   return (
-    <div className="sticky top-0 z-40 flex h-20 shrink-0 items-center gap-x-4 border-b border-gray-200 bg-white px-4 shadow-sm sm:gap-x-6 sm:px-6 lg:px-8 pt-4">
+    <div className="z-40 flex h-20 shrink-0 items-center gap-x-4 border-b border-gray-200 bg-white px-4 shadow-sm sm:gap-x-6 sm:px-6 lg:px-8 pt-4">
       <button
         type="button"
         className="-m-2.5 p-2.5 text-gray-700 lg:hidden"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "@remix-run/react": "^2.0.0",
     "@remix-run/serve": "^2.0.0",
     "@tailwindcss/forms": "^0.5.6",
+    "@types/react-datepicker": "^4.19.3",
     "@vercel/analytics": "^1.0.2",
     "@vercel/remix": "^2.0.0",
     "algoliasearch": "^4.20.0",
@@ -24,6 +25,7 @@
     "instantsearch.js": "^4.58.0",
     "isbot": "^3.6.8",
     "react": "^18.2.0",
+    "react-datepicker": "^4.21.0",
     "react-dom": "^18.2.0",
     "react-instantsearch": "^7.2.0"
   },

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -449,7 +449,7 @@
     "@babel/plugin-transform-modules-commonjs" "^7.23.0"
     "@babel/plugin-transform-typescript" "^7.22.15"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.21.0":
   version "7.23.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.2.tgz#062b0ac103261d68a966c4c7baf2ae3e62ec3885"
   integrity sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==
@@ -931,6 +931,11 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
+"@popperjs/core@^2.11.8", "@popperjs/core@^2.9.2":
+  version "2.11.8"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
+  integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
+
 "@remix-run/css-bundle@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@remix-run/css-bundle/-/css-bundle-2.0.1.tgz#8c755948482966534cdae4010c4c878e71bfeca6"
@@ -1249,6 +1254,16 @@
   version "6.9.8"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.8.tgz#f2a7de3c107b89b441e071d5472e6b726b4adf45"
   integrity sha512-u95svzDlTysU5xecFNTgfFG5RUWu1A9P0VzgpcIiGZA9iraHOdSzcxMxQ55DyeRaGCSxQi7LxXDI4rzq/MYfdg==
+
+"@types/react-datepicker@^4.19.3":
+  version "4.19.3"
+  resolved "https://registry.yarnpkg.com/@types/react-datepicker/-/react-datepicker-4.19.3.tgz#0a58e42d820adf12337617bd72289766643775db"
+  integrity sha512-85F9eKWu9fGiD9r4KVVMPYAdkJJswR3Wci9PvqplmB6T+D+VbUqPeKtifg96NZ4nEhufjehW+SX4JLrEWVplWw==
+  dependencies:
+    "@popperjs/core" "^2.9.2"
+    "@types/react" "*"
+    date-fns "^2.0.1"
+    react-popper "^2.2.5"
 
 "@types/react-dom@^18.2.7":
   version "18.2.9"
@@ -1942,6 +1957,11 @@ chownr@^2.0.0:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
+classnames@^2.2.6:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
+  integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
+
 clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
@@ -2103,6 +2123,13 @@ data-uri-to-buffer@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz#594b8973938c5bc2c33046535785341abc4f3636"
   integrity sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==
+
+date-fns@^2.0.1, date-fns@^2.30.0:
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.30.0.tgz#f367e644839ff57894ec6ac480de40cae4b0f4d0"
+  integrity sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==
+  dependencies:
+    "@babel/runtime" "^7.21.0"
 
 debug@2.6.9:
   version "2.6.9"
@@ -3925,7 +3952,7 @@ longest-streak@^3.0.0:
   resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-3.1.0.tgz#62fa67cd958742a1574af9f39866364102d90cd4"
   integrity sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==
 
-loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -5143,7 +5170,7 @@ promise-retry@^2.0.1:
     err-code "^2.0.2"
     retry "^0.12.0"
 
-prop-types@^15.8.1:
+prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -5227,6 +5254,18 @@ raw-body@2.5.1:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
+react-datepicker@^4.21.0:
+  version "4.21.0"
+  resolved "https://registry.yarnpkg.com/react-datepicker/-/react-datepicker-4.21.0.tgz#09b2ba3e53654a8563b22c9f649835716c8456d3"
+  integrity sha512-z0DtuRrKMz9i7dcTusW29VacbM9pn08g1yw0cG+Y5GpodJDxSWv7zUMxl3IwKN9Ap/AMphiepvmT5P+iNCgEiA==
+  dependencies:
+    "@popperjs/core" "^2.11.8"
+    classnames "^2.2.6"
+    date-fns "^2.30.0"
+    prop-types "^15.7.2"
+    react-onclickoutside "^6.13.0"
+    react-popper "^2.3.0"
+
 react-dom@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
@@ -5234,6 +5273,11 @@ react-dom@^18.2.0:
   dependencies:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
+
+react-fast-compare@^3.0.1:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.2.tgz#929a97a532304ce9fee4bcae44234f1ce2c21d49"
+  integrity sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==
 
 react-instantsearch-core@7.2.0:
   version "7.2.0"
@@ -5263,6 +5307,19 @@ react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
+react-onclickoutside@^6.13.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.13.0.tgz#e165ea4e5157f3da94f4376a3ab3e22a565f4ffc"
+  integrity sha512-ty8So6tcUpIb+ZE+1HAhbLROvAIJYyJe/1vRrrcmW+jLsaM+/powDRqxzo6hSh9CuRZGSL1Q8mvcF5WRD93a0A==
+
+react-popper@^2.2.5, react-popper@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.3.0.tgz#17891c620e1320dce318bad9fede46a5f71c70ba"
+  integrity sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==
+  dependencies:
+    react-fast-compare "^3.0.1"
+    warning "^4.0.2"
 
 react-refresh@^0.14.0:
   version "0.14.0"
@@ -6342,6 +6399,13 @@ vite-node@^0.28.5:
     rollup "^3.27.1"
   optionalDependencies:
     fsevents "~2.3.2"
+
+warning@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
+  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
+  dependencies:
+    loose-envify "^1.0.0"
 
 wcwidth@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
# Overview

Adds the ability to perform basic date filtering based on the `endDate` of an `adDisclosure`.

## Screenshots
<img width="1678" alt="CLC Ad Transparency Database 2023-11-16 21-33-13" src="https://github.com/maplight/clc-ad-transparency/assets/38389357/a2ca1b2d-bb7a-4002-99e3-3d0068270aac">
<img width="1669" alt="CLC Ad Transparency Database 2023-11-16 21-33-35" src="https://github.com/maplight/clc-ad-transparency/assets/38389357/c50d774e-36d4-4b45-bc21-e57cc6a1d66b">
<img width="1229" alt="CLC Ad Transparency Database 2023-11-16 22-05-50" src="https://github.com/maplight/clc-ad-transparency/assets/38389357/14ad7df1-1607-4b2f-9a3e-5e8159a28dc1">
