### PR TITLE
[FEATURE] Target search CLCAD-75

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -46,17 +46,23 @@ adDisclosuresIndex.setSettings({
     "adFormat",
     "adSpend",
     "afterDistinct(searchable(filerName))",
-    "candidates.lvl0",
+    "afterDistinct(searchable(candidates.lvl0))",
     "candidates.lvl1",
-    "measures.lvl0",
+    "afterDistinct(searchable(measures.lvl0))",
     "measures.lvl1",
-    "politicalParties.lvl0",
+    "afterDistinct(searchable(politicalParties.lvl0))",
     "politicalParties.lvl1",
     "startDateTimestamp",
     "endDateTimestamp",
   ],
   replicas,
-  searchableAttributes: ["adTextContent"],
+  searchableAttributes: [
+    "adTextContent",
+    "filerName",
+    "candidates.lvl0",
+    "measures.lvl0",
+    "politicalParties.lvl0",
+  ],
 });
 
 replicaIndices.forEach((replicaIndex) => {

--- a/frontend/app/components/Search/FiltersSidebar/SearchFilters/index.tsx
+++ b/frontend/app/components/Search/FiltersSidebar/SearchFilters/index.tsx
@@ -1,4 +1,4 @@
-import { HierarchicalMenu, Menu, RefinementList } from "react-instantsearch";
+import { Menu, RefinementList } from "react-instantsearch";
 import MenuSelect from "~/components/MenuSelect";
 import NumericMenu from "~/components/NumericMenu";
 import DateSelect from "~/components/DateSelect";
@@ -30,34 +30,52 @@ const SearchFilters = () => {
       </li>
       <li>
         <Card title="Candidate">
-          <HierarchicalMenu
-            attributes={["candidates.lvl0", "candidates.lvl1"]}
+          <RefinementList
+            attribute="candidates.lvl0"
             classNames={{
-              item: "font-normal text-gray-900",
+              checkbox: "text-primary-500 focus:ring-primary-500 rounded",
               selectedItem: "font-medium text-primary-500",
+              showMore:
+                "bg-none hover:bg-none focus:bg-none bg-primary-600 hover:bg-primary-500 focus:bg-primary-500 focus:ring-0 text-white font-bold py-2 px-4 rounded",
             }}
+            limit={5}
+            searchable
+            showMore
+            sortBy={["count:desc", "name:asc", "isRefined:asc"]}
           />
         </Card>
       </li>
       <li>
         <Card title="Measure">
-          <HierarchicalMenu
-            attributes={["measures.lvl0", "measures.lvl1"]}
+          <RefinementList
+            attribute="measures.lvl0"
             classNames={{
-              item: "font-normal text-gray-900",
+              checkbox: "text-primary-500 focus:ring-primary-500 rounded",
               selectedItem: "font-medium text-primary-500",
+              showMore:
+                "bg-none hover:bg-none focus:bg-none bg-primary-600 hover:bg-primary-500 focus:bg-primary-500 focus:ring-0 text-white font-bold py-2 px-4 rounded",
             }}
+            limit={5}
+            searchable
+            showMore
+            sortBy={["count:desc", "name:asc", "isRefined:asc"]}
           />
         </Card>
       </li>
       <li>
         <Card title="Party">
-          <HierarchicalMenu
-            attributes={["politicalParties.lvl0", "politicalParties.lvl1"]}
+          <RefinementList
+            attribute="politicalParties.lvl0"
             classNames={{
-              item: "font-normal text-gray-900",
+              checkbox: "text-primary-500 focus:ring-primary-500 rounded",
               selectedItem: "font-medium text-primary-500",
+              showMore:
+                "bg-none hover:bg-none focus:bg-none bg-primary-600 hover:bg-primary-500 focus:bg-primary-500 focus:ring-0 text-white font-bold py-2 px-4 rounded",
             }}
+            limit={5}
+            searchable
+            showMore
+            sortBy={["count:desc", "name:asc", "isRefined:asc"]}
           />
         </Card>
       </li>


### PR DESCRIPTION
#Overview

Adds the ability to search on a target. Achieves this functionality by swapping out the hierarchical menus for refinement lists. This allows search on the target, however, the ability to further refine the search by position is lost. Attributes for targets (e.g. candidate, measure, etc.) are also added to `searchableAttributes` so they are searchable in the main search box.

## Screenshots 
![CLC Ad Transparency Database 2023-11-21 13-50-14](https://github.com/maplight/clc-ad-transparency/assets/38389357/c1be2271-5a2a-4a76-9296-77bcb07e6d74)
![CLC Ad Transparency Database 2023-11-21 13-52-49](https://github.com/maplight/clc-ad-transparency/assets/38389357/2eb44036-8cea-4e4e-b365-335b8fec048a)

## Task
[CLCAD-75](https://maplight.atlassian.net/browse/CLCAD-75)

[CLCAD-75]: https://maplight.atlassian.net/browse/CLCAD-75?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ