### PR TITLE
[FEATURE] Filter by office CLCAD-30

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -5,6 +5,7 @@ import generateFilingPeriodData from "./utils/generate-filing-period-data";
 import type { Attribute } from "@strapi/strapi";
 import { errors } from "@strapi/utils";
 import { parseISO } from "date-fns";
+import { candidates as candidatesConstant } from "./utils/constants";
 
 type AdDisclosure = Attribute.GetValues<"api::ad-disclosure.ad-disclosure">;
 
@@ -51,6 +52,8 @@ adDisclosuresIndex.setSettings({
     "afterDistinct(searchable(measures.lvl0))",
     "measures.lvl1",
     "afterDistinct(searchable(politicalParties.lvl0))",
+    "offices.lvl0",
+    "afterDistinct(searchable(offices.lvl0))",
     "politicalParties.lvl1",
     "startDateTimestamp",
     "endDateTimestamp",
@@ -62,6 +65,7 @@ adDisclosuresIndex.setSettings({
     "candidates.lvl0",
     "measures.lvl0",
     "politicalParties.lvl0",
+    "offices.lvl0",
   ],
 });
 
@@ -207,15 +211,20 @@ export default {
               "ad-disclosure.political-party"
             );
 
+            const candidatesLvl0 = candidates.map(lvl0FacetValues);
+
             return {
               objectID: id,
               ...adDisclosure,
-              "candidates.lvl0": candidates.map(lvl0FacetValues),
+              "candidates.lvl0": candidatesLvl0,
               "candidates.lvl1": candidates.map(lvl1FacetValues),
               "measures.lvl0": measures.map(lvl0FacetValues),
               "measures.lvl1": measures.map(lvl1FacetValues),
               "politicalParties.lvl0": politicalParties.map(lvl0FacetValues),
               "politicalParties.lvl1": politicalParties.map(lvl1FacetValues),
+              "offices.lvl0": candidatesConstant
+                .filter(({ name }) => candidatesLvl0.includes(name))
+                .map(({ office }) => office),
               filerName: registration.filerName,
               startDateTimestamp: parseISO(adDisclosure.startDate).getTime(),
               endDateTimestamp: parseISO(adDisclosure.endDate).getTime(),

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -4,26 +4,86 @@
 
 // These names should be kept in sync with the schema in backend/src/components/ad-disclosure/candidate.json
 export const candidates = [
-  { name: "Tracy Kessler-Bechtelar" },
-  { name: "Dominic Kerluke" },
-  { name: "Neil Brown" },
-  { name: "Bessie Nitzsche" },
-  { name: "Sarah Homenick" },
-  { name: "Leonard Auer" },
-  { name: "Frankie Swift Jr." },
-  { name: "Alyssa Nicolas DVM" },
-  { name: "Nora Fritsch V" },
-  { name: "Lindsey Mohr" },
-  { name: "Patty Sporer-Blick" },
-  { name: "Gilberto O'Kon-Schmitt" },
-  { name: "Bessie Hudson" },
-  { name: "Lionel Wehner IV" },
-  { name: "Hattie Schmidt" },
-  { name: "Nicolas Conn-Conn" },
-  { name: "Kellie Sipes" },
-  { name: "Roman Tremblay-Hegmann" },
-  { name: "Toni Herzog" },
-  { name: "Randolph Zieme" },
+  {
+    name: "Tracy Kessler-Bechtelar",
+    office: "Justice of the Supreme Court",
+  },
+  {
+    name: "Dominic Kerluke",
+    office: "Secretary of State",
+  },
+  {
+    name: "Neil Brown",
+    office: "Attorney General",
+  },
+  {
+    name: "Bessie Nitzsche",
+    office: "Comptroller",
+  },
+  {
+    name: "Sarah Homenick",
+    office: "Treasurer",
+  },
+  {
+    name: "Leonard Auer",
+    office: "U.S. Senator",
+  },
+  {
+    name: "Frankie Swift Jr.",
+    office: "U.S. Representative",
+  },
+  {
+    name: "Alyssa Nicolas DVM",
+    office: "State Senator",
+  },
+  {
+    name: "Nora Fritsch V",
+    office: "State Representative",
+  },
+  {
+    name: "Lindsey Mohr",
+    office: "County Board Member",
+  },
+  {
+    name: "Patty Sporer-Blick",
+    office: "County Clerk",
+  },
+  {
+    name: "Gilberto O'Kon-Schmitt",
+    office: "County Treasurer",
+  },
+  {
+    name: "Bessie Hudson",
+    office: "County Sheriff",
+  },
+  {
+    name: "Lionel Wehner IV",
+    office: "County Assessor",
+  },
+  {
+    name: "Hattie Schmidt",
+    office: "County Auditor",
+  },
+  {
+    name: "Nicolas Conn-Conn",
+    office: "County Recorder",
+  },
+  {
+    name: "Kellie Sipes",
+    office: "County Coroner",
+  },
+  {
+    name: "Roman Tremblay-Hegmann",
+    office: "County Surveyor",
+  },
+  {
+    name: "Toni Herzog",
+    office: "County Superintendent of Schools",
+  },
+  {
+    name: "Randolph Zieme",
+    office: "County Commissioner",
+  },
 ] as const;
 
 export const candidateNames = candidates.map(({ name }) => name);

--- a/frontend/app/components/Search/FiltersSidebar/SearchFilters/index.tsx
+++ b/frontend/app/components/Search/FiltersSidebar/SearchFilters/index.tsx
@@ -46,6 +46,23 @@ const SearchFilters = () => {
         </Card>
       </li>
       <li>
+        <Card title="Office">
+          <RefinementList
+            attribute="offices.lvl0"
+            classNames={{
+              checkbox: "text-primary-500 focus:ring-primary-500 rounded",
+              selectedItem: "font-medium text-primary-500",
+              showMore:
+                "bg-none hover:bg-none focus:bg-none bg-primary-600 hover:bg-primary-500 focus:bg-primary-500 focus:ring-0 text-white font-bold py-2 px-4 rounded",
+            }}
+            limit={5}
+            searchable
+            showMore
+            sortBy={["count:desc", "name:asc", "isRefined:asc"]}
+          />
+        </Card>
+      </li>
+      <li>
         <Card title="Measure">
           <RefinementList
             attribute="measures.lvl0"


### PR DESCRIPTION
# Overview

Adds the ability to filter by a candidate's office.

## Screenshots
![CLC Ad Transparency Database 2023-11-21 14-29-22](https://github.com/maplight/clc-ad-transparency/assets/38389357/61f4f32a-72d0-4703-9af9-106963b783f6)
![CLC Ad Transparency Database 2023-11-21 14-29-41](https://github.com/maplight/clc-ad-transparency/assets/38389357/a41fbeb6-6a79-49d3-82cc-258fa77b2795)

## Task
[CLCAD-30](https://maplight.atlassian.net/browse/CLCAD-30)

[CLCAD-30]: https://maplight.atlassian.net/browse/CLCAD-30?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ