### PR TITLE
[FEATURE] Add all option for menu selects CLCAD-79

### DIFF
--- a/frontend/app/components/MenuSelect/index.tsx
+++ b/frontend/app/components/MenuSelect/index.tsx
@@ -15,6 +15,7 @@ const MenuSelect = (props: UseMenuProps) => {
         refine((event.target as HTMLSelectElement).value);
       }}
     >
+      <option value="">All</option>
       {items.map((item, index) => (
         <option key={index} value={item.value}>
           {item.label}


### PR DESCRIPTION
# Overview

Adds an `All` option for the `MenuSelect` component to allow users to clear the selection and update the search results.

<img width="648" alt="CLC Ad Transparency Database 2024-01-17 11-51-59" src="https://github.com/maplight/clc-ad-transparency/assets/38389357/5649f9e9-1a9b-432c-b1c5-325f54526894">


## Task
[CLCAD-79](https://maplight.atlassian.net/browse/CLCAD-79) 

[CLCAD-79]: https://maplight.atlassian.net/browse/CLCAD-79?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ